### PR TITLE
Add bounded worker-pool dispatcher with configurable worker_count

### DIFF
--- a/src/buffer.py
+++ b/src/buffer.py
@@ -19,7 +19,7 @@ class JobBuffer(ABC):
         pass
 
     @abstractmethod
-    def dequeue(self) -> Optional[Job]:
+    def dequeue(self, timeout: float = 0.1) -> Optional[Job]:
         pass
 
     @abstractmethod
@@ -56,9 +56,9 @@ class InMemoryJobBuffer(JobBuffer):
             self._job_queue.put(job)
             self._jobs_enqueued += 1
 
-    def dequeue(self) -> Optional[Job]:
+    def dequeue(self, timeout: float = 0.1) -> Optional[Job]:
         try:
-            job = self._job_queue.get_nowait()
+            job = self._job_queue.get(timeout=timeout)
             # self._lock is intentional: Queue's internal lock guards only the
             # queue itself, not _jobs_in_progress, which is also read/written
             # by complete_job() and is_finished() under the same lock.

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ class ScanConfiguration:
     excluded_directories: list[str]
     excluded_pans: list[str]
     size_limit: int
+    worker_count: int
     quiet: bool
     report_file: str
     json_file: str
@@ -33,6 +34,7 @@ class ScanConfiguration:
         self.json_dir = None
         self.excluded_pans = []
         self.size_limit = 1_073_741_824  # 1GB
+        self.worker_count = 1
         self.quiet = False
         self.report_file = f'panhunt_{time.strftime("%Y-%m-%d-%H%M%S")}.report'
         self.json_file = f'panhunt_{time.strftime("%Y-%m-%d-%H%M%S")}.json'
@@ -57,6 +59,7 @@ class ScanConfiguration:
                   excluded_directories_string: Optional[str] = None,
                   excluded_pans_string: Optional[str] = None,
                   size_limit: Optional[int] = None,
+                  worker_count: Optional[int] = None,
                   quiet: Optional[bool] = None) -> 'ScanConfiguration':
 
         config = cls()
@@ -68,6 +71,7 @@ class ScanConfiguration:
             excluded_directories_string=excluded_directories_string,
             excluded_pans_string=excluded_pans_string,
             size_limit=size_limit,
+            worker_count=worker_count,
             quiet=quiet
         )
         return config
@@ -87,6 +91,7 @@ class ScanConfiguration:
             excluded_directories_string=cls._try_parse(raw, 'exclude'),
             excluded_pans_string=cls._try_parse(raw, 'excludepans'),
             size_limit=cls._try_parse_int(raw, 'sizelimit'),
+            worker_count=cls._try_parse_int(raw, 'workers'),
             quiet=quiet if quiet is not None else cls._try_parse_bool(raw, 'quiet'),
         )
 
@@ -98,6 +103,7 @@ class ScanConfiguration:
                 excluded_directories_string: Optional[str],
                 excluded_pans_string: Optional[str],
                 size_limit: Optional[int],
+                worker_count: Optional[int] = None,
                 quiet: Optional[bool] = None) -> None:
 
         if search_dir and search_dir != 'None':
@@ -120,6 +126,11 @@ class ScanConfiguration:
 
         if size_limit is not None:
             self.size_limit = size_limit
+
+        if worker_count is not None:
+            if worker_count < 1:
+                raise ValueError("worker_count must be a positive integer")
+            self.worker_count = worker_count
 
         if quiet is not None:
             self.quiet = quiet

--- a/src/dispatcher.py
+++ b/src/dispatcher.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import threading
-import time
 from io import IOBase
 from typing import Optional
 
@@ -21,25 +20,39 @@ class Dispatcher:
     findings: list[Finding]
     failures: list[Finding]
 
-    _stop_flag: bool
+    _stop_event: threading.Event
+    _threads: list[threading.Thread]
     __findings_lock: threading.Lock
 
     def __init__(self, buffer: JobBuffer, config: ScanConfiguration) -> None:
         self._buffer = buffer
         self._config = config
         self._scanner_factory = ScannerFactory(buffer=buffer, config=config)
-        self._stop_flag = False
+        self._stop_event = threading.Event()
+        self._threads = []
         self.findings = []
         self.failures = []
         self.__findings_lock = threading.Lock()
 
     def start(self) -> None:
-        self._stop_flag = False
-        dispatch_thread = threading.Thread(target=self._run_dispatch_loop, daemon=True)
-        dispatch_thread.start()
+        self._stop_event.clear()
+        self._threads = [
+            threading.Thread(
+                target=self._run_dispatch_loop,
+                name=f"panhunt-worker-{i}",
+                daemon=False,
+            )
+            for i in range(self._config.worker_count)
+        ]
+        for thread in self._threads:
+            thread.start()
 
     def stop(self) -> None:
-        self._stop_flag = True
+        self._stop_event.set()
+
+    def join(self) -> None:
+        for thread in self._threads:
+            thread.join()
 
     def get_findings(self) -> list[Finding]:
         with self.__findings_lock:
@@ -50,30 +63,29 @@ class Dispatcher:
             return list(self.failures)
 
     def _run_dispatch_loop(self) -> None:
-        while not self._stop_flag and not self._buffer.is_finished():
-            if self._buffer.has_jobs():
-                job: Optional[Job] = self._buffer.dequeue()
-
-                if job:
+        while not self._stop_event.is_set():
+            job: Optional[Job] = self._buffer.dequeue(timeout=0.1)
+            if job is None:
+                if self._buffer.is_finished():
+                    break
+                continue
+            try:
+                res: Optional[Finding] = self._dispatch_job(job)
+                if res is not None:
+                    with self.__findings_lock:
+                        if res.status == enums.ScanStatusEnum.Success:
+                            self.findings.append(res)
+                        else:
+                            self.failures.append(res)
+            finally:
+                if job.payload and isinstance(job.payload, IOBase):
                     try:
-                        res: Optional[Finding] = self._dispatch_job(job)
-                        if res is not None:
-                            with self.__findings_lock:
-                                if res.status == enums.ScanStatusEnum.Success:
-                                    self.findings.append(res)
-                                else:
-                                    self.failures.append(res)
-                    finally:
-                        if job.payload and isinstance(job.payload, IOBase):
-                            try:
-                                job.payload.close()
-                            except Exception as e:
-                                logging.warning(f"Failed to close payload for {job.abspath}: {e}")
-                        job.payload = None
-                        job = None
-                        self._buffer.complete_job()
-            else:
-                time.sleep(0.1)
+                        job.payload.close()
+                    except Exception as e:
+                        logging.warning(f"Failed to close payload for {job.abspath}: {e}")
+                job.payload = None
+                job = None
+                self._buffer.complete_job()
 
     def _dispatch_job(self, job: Job) -> Optional[Finding]:
         logging.info(f"Processing job: {job.abspath}")

--- a/src/hunter.py
+++ b/src/hunter.py
@@ -37,7 +37,10 @@ class Hunter:
         while not self._buffer.is_finished():
             time.sleep(0.1)
 
-        return self._dispatcher.findings, self._dispatcher.failures
+        self._dispatcher.stop()
+        self._dispatcher.join()
+
+        return self._dispatcher.get_findings(), self._dispatcher.get_failures()
 
     def _is_directory_excluded(self, dirname: str, config: ScanConfiguration) -> bool:
         sep = os.sep

--- a/src/panhunt.py
+++ b/src/panhunt.py
@@ -50,6 +50,7 @@ def main() -> None:
     arg_parser.add_argument('-j', dest='json_dir', help='Report file directory for JSON formatted PAN report', default=None)
     arg_parser.add_argument('-C', dest='config', help='configuration file to use')
     arg_parser.add_argument('-X', dest='exclude_pan', help='PAN to exclude from search')
+    arg_parser.add_argument('-w', dest='workers', type=int, default=None, help='Number of worker threads (default: 1)')
     arg_parser.add_argument('-q', dest='quiet', action='store_true', default=False, help='No terminal output')
 
     args = arg_parser.parse_args()
@@ -71,6 +72,7 @@ def main() -> None:
             json_dir=args.json_dir,
             excluded_directories_string=args.exclude_dirs,
             excluded_pans_string=args.exclude_pan,
+            worker_count=args.workers,
             quiet=args.quiet)
 
     result = PanHuntService().scan(config)

--- a/src/tests/test_buffer.py
+++ b/src/tests/test_buffer.py
@@ -91,6 +91,60 @@ class TestThreadSafety:
         assert count == 200
 
 
+class TestBlockingDequeue:
+    def test_dequeue_returns_none_on_empty_with_timeout(self):
+        b = InMemoryJobBuffer()
+        start = time.monotonic()
+        result = b.dequeue(timeout=0.05)
+        elapsed = time.monotonic() - start
+        assert result is None
+        assert elapsed >= 0.05
+
+    def test_dequeue_returns_job_immediately_when_available(self):
+        b = InMemoryJobBuffer()
+        b.enqueue(_make_job())
+        start = time.monotonic()
+        result = b.dequeue(timeout=1.0)
+        elapsed = time.monotonic() - start
+        assert result is not None
+        assert elapsed < 0.5
+
+    def test_blocking_dequeue_safe_for_multiple_consumers(self):
+        b = InMemoryJobBuffer()
+        num_jobs = 40
+        for i in range(num_jobs):
+            b.enqueue(_make_job(f'file_{i}.txt'))
+        b.mark_input_complete()
+
+        results = []
+        lock = threading.Lock()
+        errors = []
+
+        def consumer():
+            try:
+                while True:
+                    job = b.dequeue(timeout=0.1)
+                    if job is None:
+                        if b.is_finished():
+                            break
+                        continue
+                    with lock:
+                        results.append(job.basename)
+                    b.complete_job()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=consumer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(results) == num_jobs
+        assert len(set(results)) == num_jobs
+
+
 class TestMemoryCheck:
     def test_large_payload_raises_memory_error(self):
         from unittest.mock import MagicMock, patch

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -32,6 +32,9 @@ class TestDefaults:
     def test_default_size_limit(self):
         assert ScanConfiguration().size_limit == 1_073_741_824
 
+    def test_default_worker_count(self):
+        assert ScanConfiguration().worker_count == 1
+
     def test_report_file_has_timestamp(self):
         c = ScanConfiguration()
         assert c.report_file.startswith('panhunt_')
@@ -66,6 +69,18 @@ class TestFromArgs:
     def test_size_limit_override(self):
         c = ScanConfiguration.from_args(size_limit=512)
         assert c.size_limit == 512
+
+    def test_worker_count_override(self):
+        c = ScanConfiguration.from_args(worker_count=4)
+        assert c.worker_count == 4
+
+    def test_invalid_worker_count_raises(self):
+        with pytest.raises(ValueError, match='worker_count'):
+            ScanConfiguration.from_args(worker_count=0)
+
+    def test_negative_worker_count_raises(self):
+        with pytest.raises(ValueError, match='worker_count'):
+            ScanConfiguration.from_args(worker_count=-1)
 
     def test_none_string_is_ignored(self):
         c = ScanConfiguration.from_args(search_dir='None')
@@ -108,6 +123,11 @@ class TestFromFile:
         ini = self._write_ini(tmp_path, '[DEFAULT]\nsizelimit=1024\n')
         c = ScanConfiguration.from_file(ini)
         assert c.size_limit == 1024
+
+    def test_workers_from_file(self, tmp_path):
+        ini = self._write_ini(tmp_path, '[DEFAULT]\nworkers=4\n')
+        c = ScanConfiguration.from_file(ini)
+        assert c.worker_count == 4
 
 
 class TestHelpers:

--- a/src/tests/test_dispatcher.py
+++ b/src/tests/test_dispatcher.py
@@ -1,0 +1,348 @@
+"""Tests for Dispatcher multi-worker pool."""
+
+import threading
+import time
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+import enums
+from buffer import InMemoryJobBuffer
+from config import ScanConfiguration
+from dispatcher import Dispatcher
+from finding import Finding
+from job import Job
+
+
+def _make_job(name: str = 'test.txt') -> Job:
+    return Job(basename=name, dirname='/tmp')
+
+
+def _make_config(worker_count: int = 1) -> ScanConfiguration:
+    return ScanConfiguration.from_args(search_dir='/tmp', quiet=True, worker_count=worker_count)
+
+
+def _success_finding() -> Finding:
+    f = MagicMock(spec=Finding)
+    f.status = enums.ScanStatusEnum.Success
+    return f
+
+
+def _failure_finding() -> Finding:
+    f = MagicMock(spec=Finding)
+    f.status = enums.ScanStatusEnum.Failure
+    return f
+
+
+def _wait_for_finish(buffer: InMemoryJobBuffer, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not buffer.is_finished():
+        if time.monotonic() > deadline:
+            raise TimeoutError("Buffer did not finish within timeout")
+        time.sleep(0.01)
+
+
+class TestDispatcherLifecycle:
+    def test_start_stop_join_empty_buffer(self):
+        buffer = InMemoryJobBuffer()
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+    def test_join_completes_after_stop(self):
+        buffer = InMemoryJobBuffer()
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+        assert all(not t.is_alive() for t in d._threads)
+
+    def test_multi_worker_all_threads_start(self):
+        buffer = InMemoryJobBuffer()
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=4))
+        d.start()
+        assert len(d._threads) == 4
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+
+class TestSingleWorkerCompatibility:
+    def test_single_worker_processes_job(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job('file.txt'))
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=1))
+        d._dispatch_job = MagicMock(return_value=_success_finding())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+        assert d._dispatch_job.call_count == 1
+        assert len(d.get_findings()) == 1
+        assert len(d.get_failures()) == 0
+
+    def test_single_worker_collects_failure(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job())
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=1))
+        d._dispatch_job = MagicMock(return_value=_failure_finding())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+        assert len(d.get_failures()) == 1
+        assert len(d.get_findings()) == 0
+
+    def test_single_worker_none_result_not_collected(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job())
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=1))
+        d._dispatch_job = MagicMock(return_value=None)
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+        assert len(d.get_findings()) == 0
+        assert len(d.get_failures()) == 0
+
+
+class TestMultiWorkerProcessing:
+    def test_all_jobs_processed_no_duplicates(self):
+        num_jobs = 50
+        buffer = InMemoryJobBuffer()
+        for i in range(num_jobs):
+            buffer.enqueue(_make_job(f'file_{i}.txt'))
+        buffer.mark_input_complete()
+
+        processed = []
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                processed.append(job.basename)
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=4))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert len(processed) == num_jobs
+        assert len(set(processed)) == num_jobs
+
+    def test_no_missed_jobs_under_load(self):
+        num_jobs = 100
+        buffer = InMemoryJobBuffer()
+        job_names = {f'job_{i}.txt' for i in range(num_jobs)}
+        for name in job_names:
+            buffer.enqueue(_make_job(name))
+        buffer.mark_input_complete()
+
+        seen: set[str] = set()
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                seen.add(job.basename)
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=8))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert seen == job_names
+
+    def test_worker_count_greater_than_job_count(self):
+        buffer = InMemoryJobBuffer()
+        for i in range(3):
+            buffer.enqueue(_make_job(f'file_{i}.txt'))
+        buffer.mark_input_complete()
+
+        call_count = [0]
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                call_count[0] += 1
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=10))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert call_count[0] == 3
+
+
+class TestConcurrentResultCollection:
+    def test_concurrent_findings_count(self):
+        num_jobs = 60
+        buffer = InMemoryJobBuffer()
+        for i in range(num_jobs):
+            buffer.enqueue(_make_job(f'file_{i}.txt'))
+        buffer.mark_input_complete()
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=4))
+        d._dispatch_job = MagicMock(side_effect=lambda job: _success_finding())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert len(d.get_findings()) == num_jobs
+
+    def test_concurrent_failures_count(self):
+        num_jobs = 40
+        buffer = InMemoryJobBuffer()
+        for i in range(num_jobs):
+            buffer.enqueue(_make_job(f'file_{i}.txt'))
+        buffer.mark_input_complete()
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=4))
+        d._dispatch_job = MagicMock(side_effect=lambda job: _failure_finding())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert len(d.get_failures()) == num_jobs
+        assert len(d.get_findings()) == 0
+
+    def test_get_findings_returns_snapshot(self):
+        buffer = InMemoryJobBuffer()
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config())
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        snapshot1 = d.get_findings()
+        snapshot2 = d.get_findings()
+        assert snapshot1 is not snapshot2
+
+
+class TestArchiveChildJobs:
+    def test_archive_children_are_processed(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job('archive.zip'))
+        buffer.mark_input_complete()
+
+        processed = []
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                processed.append(job.basename)
+            if job.basename == 'archive.zip':
+                buffer.enqueue(_make_job('child.txt'))
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=2))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert 'archive.zip' in processed
+        assert 'child.txt' in processed
+        assert len(processed) == 2
+
+    def test_archive_with_multiple_children(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job('archive.zip'))
+        buffer.mark_input_complete()
+
+        child_names = [f'child_{i}.txt' for i in range(5)]
+        processed = []
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                processed.append(job.basename)
+            if job.basename == 'archive.zip':
+                for name in child_names:
+                    buffer.enqueue(_make_job(name))
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=2))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert set(processed) == {'archive.zip'} | set(child_names)
+
+    def test_nested_archive_children_processed(self):
+        buffer = InMemoryJobBuffer()
+        buffer.enqueue(_make_job('outer.zip'))
+        buffer.mark_input_complete()
+
+        processed = []
+        lock = threading.Lock()
+
+        def mock_dispatch(job):
+            with lock:
+                processed.append(job.basename)
+            if job.basename == 'outer.zip':
+                buffer.enqueue(_make_job('inner.zip'))
+            elif job.basename == 'inner.zip':
+                buffer.enqueue(_make_job('leaf.txt'))
+            return None
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=2))
+        d._dispatch_job = mock_dispatch
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        assert set(processed) == {'outer.zip', 'inner.zip', 'leaf.txt'}
+
+
+class TestShutdownBehavior:
+    def test_stop_signals_workers_to_exit(self):
+        buffer = InMemoryJobBuffer()
+        buffer.mark_input_complete()
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=2))
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+        assert all(not t.is_alive() for t in d._threads)
+
+    def test_complete_job_called_exactly_once_per_job(self):
+        num_jobs = 20
+        buffer = InMemoryJobBuffer()
+        for i in range(num_jobs):
+            buffer.enqueue(_make_job(f'file_{i}.txt'))
+        buffer.mark_input_complete()
+
+        d = Dispatcher(buffer=buffer, config=_make_config(worker_count=4))
+        d._dispatch_job = MagicMock(return_value=None)
+        d.start()
+        _wait_for_finish(buffer)
+        d.stop()
+        d.join()
+
+        # is_finished() only returns True when all jobs are completed exactly once
+        assert buffer.is_finished()

--- a/src/tests/test_hunter.py
+++ b/src/tests/test_hunter.py
@@ -15,8 +15,8 @@ from job import Job
 @pytest.fixture
 def mock_dispatcher():
     d = MagicMock(spec=Dispatcher)
-    d.findings = []
-    d.failures = []
+    d.get_findings.return_value = []
+    d.get_failures.return_value = []
     return d
 
 
@@ -70,11 +70,19 @@ class TestHuntResults:
     def test_returns_findings_and_failures(self, mock_dispatcher, mock_buffer, tmp_dir):
         finding = MagicMock(spec=Finding)
         failure = MagicMock(spec=Finding)
-        mock_dispatcher.findings = [finding]
-        mock_dispatcher.failures = [failure]
+        mock_dispatcher.get_findings.return_value = [finding]
+        mock_dispatcher.get_failures.return_value = [failure]
         config = ScanConfiguration.from_args(search_dir=tmp_dir, quiet=True)
         mock_buffer.is_finished.return_value = True
         h = Hunter(dispatcher=mock_dispatcher, buffer=mock_buffer)
         findings, failures = h.hunt(config)
         assert findings == [finding]
         assert failures == [failure]
+
+    def test_stop_and_join_called_after_buffer_finished(self, mock_dispatcher, mock_buffer, tmp_dir):
+        config = ScanConfiguration.from_args(search_dir=tmp_dir, quiet=True)
+        mock_buffer.is_finished.return_value = True
+        h = Hunter(dispatcher=mock_dispatcher, buffer=mock_buffer)
+        h.hunt(config)
+        mock_dispatcher.stop.assert_called_once()
+        mock_dispatcher.join.assert_called_once()


### PR DESCRIPTION
Refactors the dispatcher and buffer into a proper multi-worker pipeline:

- ScanConfiguration gains `worker_count` (default 1, preserving current   behaviour); settable via `-w` CLI flag or `workers` in the INI config file; validated to be a positive integer.
- InMemoryJobBuffer.dequeue() switches from get_nowait() to a timeout-based blocking get(), making it safe for multiple concurrent consumers without the TOCTOU race between has_jobs() + dequeue().
- Dispatcher now spawns `worker_count` non-daemon threads in start(), exposes a join() method for deterministic shutdown, and uses a threading.Event instead of a plain bool for the stop signal. The dispatch loop calls the blocking dequeue directly and breaks when the buffer reports finished, so has_jobs() is no longer used as a consumer gate.
- Hunter.hunt() calls dispatcher.stop() + dispatcher.join() after the buffer finishes and returns locked snapshots via get_findings() / get_failures() instead of accessing the raw lists.

Tests: new test_dispatcher.py covers lifecycle, single-worker compatibility, multi-worker no-duplicate / no-miss guarantees, concurrent result collection, archive child-job expansion, and shutdown behaviour. Existing test_buffer.py, test_config.py, and test_hunter.py are updated
to match the new contracts (161 tests, all passing).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-worker dispatcher with a configurable worker pool to run scans in parallel. Fixes buffer race conditions and ensures clean, deterministic shutdown while keeping single-worker behavior by default.

- New Features
  - `ScanConfiguration`: adds `worker_count` (default 1); set via `-w` CLI flag or `workers` in INI; validated > 0.
  - Dispatcher: spawns `worker_count` non-daemon threads; uses a stop event and exposes `join()` for clean shutdown.
  - Hunter: stops and joins the dispatcher; returns snapshot lists via `get_findings()` / `get_failures()`.

- Bug Fixes
  - Buffer: `dequeue()` is now blocking with a timeout, safe for multiple consumers; removes the `has_jobs()` + `dequeue()` race and busy-wait.
  - Dispatcher loop: calls blocking `dequeue()`, closes payloads, calls `complete_job()` exactly once per job, and exits when the buffer is finished.
  - Tests: add `test_dispatcher.py`; update buffer, config, and hunter tests.

<sup>Written for commit e1c2984301b98c620d36ad037f3b0730f9c653bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/PANhunt/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

